### PR TITLE
Android app id update

### DIFF
--- a/android/app/_BUCK
+++ b/android/app/_BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.testapp",
+    package = "io.dolby.rn.interactiveplayer",
 )
 
 android_resource(
     name = "res",
-    package = "com.testapp",
+    package = "io.dolby.rn.interactiveplayer",
     res = "src/main/res",
 )
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,7 +137,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId "com.testapp"
+        applicationId "io.dolby.rn.interactiveplayer"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
@@ -230,11 +230,11 @@ android {
         }
     }
     signingConfigs {
-        debug {
-            storeFile file('debug.keystore')
-            storePassword 'android'
-            keyAlias 'androiddebugkey'
-            keyPassword 'android'
+        release {
+            storeFile file('release.keystore')
+            storePassword System.env.KEYSTORE_PASSWORD
+            keyAlias System.env.KEY_ALIAS
+            keyPassword System.env.KEY_PASSWORD
         }
     }
     buildTypes {
@@ -244,7 +244,7 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/android/app/src/debug/java/io/dolby/rn/interactiveplayer/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/io/dolby/rn/interactiveplayer/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.testapp;
+package io.dolby.rn.interactiveplayer;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.testapp">
+  package="io.dolby.rn.interactiveplayer">
 
   <uses-permission android:name="android.permission.INTERNET" />
 
@@ -28,7 +28,7 @@
     android:allowBackup="false"
     android:theme="@style/AppTheme">
     <activity
-      android:name=".MainActivity"
+      android:name="io.dolby.rn.interactiveplayer.MainActivity"
       android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
       android:launchMode="singleTask"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,10 +3,19 @@
 
   <uses-permission android:name="android.permission.INTERNET" />
 
-  <uses-feature android:name="android.hardware.camera" />
-  <uses-feature android:name="android.hardware.camera.autofocus" />
+  <uses-feature android:name="android.hardware.camera"
+      android:required="false" />
+  <uses-feature android:name="android.hardware.camera.autofocus"
+      android:required="false" />
   <uses-feature android:name="android.hardware.audio.output" />
-  <uses-feature android:name="android.hardware.microphone" />
+  <uses-feature android:name="android.hardware.microphone"
+      android:required="false" />
+  <uses-feature
+      android:name="android.software.leanback"
+      android:required="false" />
+  <uses-feature
+      android:name="android.hardware.touchscreen"
+      android:required="false" />
 
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/android/app/src/main/java/io/dolby/rn/interactiveplayer/MainActivity.java
+++ b/android/app/src/main/java/io/dolby/rn/interactiveplayer/MainActivity.java
@@ -1,4 +1,4 @@
-package com.testapp;
+package io.dolby.rn.interactiveplayer;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;

--- a/android/app/src/main/java/io/dolby/rn/interactiveplayer/MainApplication.java
+++ b/android/app/src/main/java/io/dolby/rn/interactiveplayer/MainApplication.java
@@ -1,4 +1,4 @@
-package com.testapp;
+package io.dolby.rn.interactiveplayer;
 
 import android.app.Application;
 import android.content.Context;
@@ -9,7 +9,8 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.soloader.SoLoader;
-import com.testapp.newarchitecture.MainApplicationReactNativeHost;
+import io.dolby.rn.interactiveplayer.newarchitecture.MainApplicationReactNativeHost;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -77,7 +78,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.testapp.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("io.dolby.rn.interactiveplayer.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/android/app/src/main/java/io/dolby/rn/interactiveplayer/newarchitecture/MainApplicationReactNativeHost.java
+++ b/android/app/src/main/java/io/dolby/rn/interactiveplayer/newarchitecture/MainApplicationReactNativeHost.java
@@ -1,4 +1,4 @@
-package com.testapp.newarchitecture;
+package io.dolby.rn.interactiveplayer.newarchitecture;
 
 import android.app.Application;
 import androidx.annotation.NonNull;
@@ -19,9 +19,11 @@ import com.facebook.react.fabric.CoreComponentsRegistry;
 import com.facebook.react.fabric.FabricJSIModuleProvider;
 import com.facebook.react.fabric.ReactNativeConfig;
 import com.facebook.react.uimanager.ViewManagerRegistry;
-import com.testapp.BuildConfig;
-import com.testapp.newarchitecture.components.MainComponentsRegistry;
-import com.testapp.newarchitecture.modules.MainApplicationTurboModuleManagerDelegate;
+
+import io.dolby.rn.interactiveplayer.BuildConfig;
+import io.dolby.rn.interactiveplayer.newarchitecture.components.MainComponentsRegistry;
+import io.dolby.rn.interactiveplayer.newarchitecture.modules.MainApplicationTurboModuleManagerDelegate;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/android/app/src/main/java/io/dolby/rn/interactiveplayer/newarchitecture/components/MainComponentsRegistry.java
+++ b/android/app/src/main/java/io/dolby/rn/interactiveplayer/newarchitecture/components/MainComponentsRegistry.java
@@ -1,4 +1,4 @@
-package com.testapp.newarchitecture.components;
+package io.dolby.rn.interactiveplayer.newarchitecture.components;
 
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;

--- a/android/app/src/main/java/io/dolby/rn/interactiveplayer/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java
+++ b/android/app/src/main/java/io/dolby/rn/interactiveplayer/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java
@@ -1,4 +1,4 @@
-package com.testapp.newarchitecture.modules;
+package io.dolby.rn.interactiveplayer.newarchitecture.modules;
 
 import com.facebook.jni.HybridData;
 import com.facebook.react.ReactPackage;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         buildToolsVersion = "31.0.0"
         minSdkVersion = 21
         compileSdkVersion = 33
-        targetSdkVersion = 31
+        targetSdkVersion = 33
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
Changes for publishing into Play Store:
- target SDK bumped to 33
- app id changed from default
- app permissions to required=false to support both mobile and TV