### PR TITLE
Fix manual steps in iOS and tvOS project setup & WebRTC xcframework consumption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '2.7.7'
+ruby '3.1.2'
 
-gem 'cocoapods', '~> 1.11', '>= 1.11.3'
+gem 'cocoapods', '1.14.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,24 +3,31 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.7.2)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.4)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
     claide (1.1.0)
-    cocoapods (1.12.1)
+    cocoapods (1.14.3)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.12.1)
+      cocoapods-core (= 1.14.3)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.6.0, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.6.0, < 2.0)
@@ -32,8 +39,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.12.1)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.14.3)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -44,7 +51,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.6.3)
+    cocoapods-downloader (2.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -54,30 +61,35 @@ GEM
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    drb (2.2.0)
+      ruby2_keywords
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
-    minitest (5.19.0)
+    json (2.7.1)
+    minitest (5.21.1)
     molinillo (0.8.0)
+    mutex_m (0.2.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     public_suffix (4.0.7)
-    rexml (3.2.5)
+    rexml (3.2.6)
     ruby-macho (2.5.1)
-    typhoeus (1.4.0)
+    ruby2_keywords (0.0.5)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.22.0)
+    xcodeproj (1.23.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -86,13 +98,14 @@ GEM
       rexml (~> 3.2.4)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.11, >= 1.11.3)
+  cocoapods (= 1.14.3)
 
 RUBY VERSION
-   ruby 2.7.7p221
+   ruby 3.1.2p20
 
 BUNDLED WITH
-   2.1.4
+   2.5.4

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ To give your Android emulator access to your microphone, start your emulator and
 
 <img src="assets/setMicAndroidEmulator.png" alt="drawing" width="500"/>
 
-
 ## How to build and run the React Native Sample App
 
 ### Apple
@@ -130,102 +129,36 @@ To give your Android emulator access to your microphone, start your emulator and
 The following steps are common for all Apple devices.
 
 1. Clone this repository.
-2. Install the dependencies:
+
+2. `WebRTC.framework` is a required dependency for the iOS/tvOS apps. You can find it in `ios/libWebRTC.zip`. To download the zip file from Git LFS is needed to run the command `git lfs pull`.
+
+3. Install the dependencies:
 ```
 yarn
 ```
-3. Then, execute:
+
+4. Then, execute:
 ```
-cd ios && pod install
+cd ios && bundle exec pod install
 ```
-
-4. It is required to have `WebRTC.framework` M112 builds. You can find it in `ios/libWebRTC.zip`.
-
-5. To download the zip file from Git LFS is needed to run the command `git lfs pull`.
-
-6. Unzip `libWebRTC` inside the `ios` folder from this project. See [remark (**)](#remark-**).
-
 
 #### iOS
 
 1. Open Xcode.
 2. Select `Open a project from a file` and then select `/streaming-sdk-react-native-getting-started/ios/TestApp.xcworkspace`.
 3. Select `TestApp project`, then `TestApp` target.
-4. Go to `General -> Frameworks, Libraries, and Embedded Content` and add `WebRTC.framework` M112 build for iOS.
-Check if the framework appears in `Build Phases -> Embed Frameworks` on `Link Binary With Libraries`, if not, add it.
-5. Then select `Pods` Xcode project and go to `Build Settings -> Search Paths`.
-
-- In `Frameworks Search Paths`, insert the following line: 
-```
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/ios-arm64
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/ios-arm64-simulator
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/ios-x64-simulator
-```
-
-- In `Header Search Paths`, insert the following lines: 
-```
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/ios-arm64/WebRTC.framework/Headers
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/ios-arm64-simulator/WebRTC.framework/Headers
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/ios-x64-simulator/WebRTC.framework/Headers
-```
-
-6. Select `TestApp` project and use an iOS simulator with iOS 16.
-
-7. Run the project, you should see the simulator with the app home page with a button to publish or subscribe to a stream.
+4. Select `TestApp` project and use an iOS simulator with iOS 16.
+5. Run the project, you should see the simulator with the app home page with a button to publish or subscribe to a stream.
 
 #### tvOS
-
-##### Xcode settings
 
 1. Open Xcode.
 2. Select `Open a project from a file` and then select `/streaming-sdk-react-native-getting-started/ios/TestApp.xcworkspace`.
 3. Select `TestApp project`, then `TestApp-tvOS` target.
-4. Go to `General -> Frameworks, Libraries, and Embedded Content` and add `WebRTC.framework` M112 build for tvOS.
-Also, add the framework in `Build Phases -> Embed Frameworks` and on `Link Binary With Libraries`.
-5. Then select `Pods` Xcode project and go to `Build Settings -> Search Paths`.
-
-![Adding WebRTC local reference in Pods target](assets/WebRTC-References-Pods.png)
-
-###### For Simulator only (*):
-
-- In `Frameworks Search Paths`, insert the following line: 
-```
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/tvos-x64-simulator
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/tvos-arm64-simulator
-```
-
-- In `Header Search Paths`, insert the following lines: 
-```
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/tvos-x64-simulator/WebRTC.framework/Headers
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/tvos-arm64-simulator/WebRTC.framework/Headers
-```
-
-###### For Real Device only (*):
-
-- In `Frameworks Search Paths`, insert the following line: 
-```
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/tvos-arm64
-```
-
-- In `Header Search Paths`, insert the following lines: 
-```
-$(PROJECT_DIR)/../libWebRTC/WebRTC.xcframework/tvos-arm64/WebRTC.framework/Headers
-```
-
-
-6. Select `TestApp-tvOS` project and use a tvOS simulator with tvOS 16.
-
-7. Run the project, you should see the simulator with the app home page with a buttom to subscribe to a stream.
+4. Select `TestApp-tvOS` project and use a tvOS simulator with tvOS 16.
+5. Run the project, you should see the simulator with the app home page with a buttom to subscribe to a stream.
 
 To navigate use the arrow keys and enter button. Also, on the Simulator window you can go to `Window -> Show Apple TV Remote` and use it.
-
-#### Remarks
-(*) The frameworks and header search paths are exclusive. If a developer is working on a platform, this developer needs to remove the search paths for the other platform.
-
-<img src="assets/Remove-old-reference-WebRTC.png" alt="drawing" width="500"/>
-
-<span id="remark-**">(**)</span> Depending on the architecture you are using, the build might be different. For instance, on mac, different builds are required for intel-based (`x64`, `x86`) and M1 based (`arm64`).
-
 
 ### Android
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -25,6 +25,8 @@ target 'TestApp' do
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
+  
+  pod 'WebRTC', :podspec => 'WebRTC/'
 
   target 'TestAppTests' do
     inherit! :complete
@@ -48,6 +50,8 @@ target 'TestApp-tvOS' do
     # An absolute path to your application root.
     :app_path => "#{Dir.pwd}/.."
   )
+
+  pod 'WebRTC', :podspec => 'WebRTC/'
 
   target 'TestApp-tvOSTests' do
     inherit! :complete

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -532,7 +532,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 1560aa917ee101aa7db67b0ea0c7fcf23f1cd969
   React-logger: e30a213559d779b696231615a145ddb29d18c742
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
-  react-native-webrtc: 559be81da074a059140db50a5f8268b6328d4fab
+  react-native-webrtc: 3ca3dfee03ed944cc6ec89c38862cbe7c9f53ab7
   React-perflogger: 6c01400e9d679980209c5debe4438eafd7e656b0
   React-RCTAnimation: 00220b81e0f8bc61cc1283544fc78d4f5cc8f857
   React-RCTBlob: a23e9da46cd0523a130b4658a22ffa758c459cc4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -270,6 +270,7 @@ PODS:
     - React-Core
   - react-native-webrtc (111.0.1):
     - React-Core
+    - WebRTC
   - React-perflogger (0.69.8-2)
   - React-RCTAnimation (0.69.8-2):
     - RCT-Folly (= 2021.06.28.00-v2)
@@ -333,7 +334,8 @@ PODS:
   - RNScreens (3.25.0):
     - React-Core
     - React-RCTImage
-  - SocketRocket (0.6.0)
+  - SocketRocket (0.6.1)
+  - WebRTC (0.0.112)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga
@@ -398,6 +400,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
+  - WebRTC (from `WebRTC/`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -489,6 +492,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  WebRTC:
+    :podspec: WebRTC/
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -527,7 +532,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 1560aa917ee101aa7db67b0ea0c7fcf23f1cd969
   React-logger: e30a213559d779b696231615a145ddb29d18c742
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
-  react-native-webrtc: ca0f8d55a2cddaf1ea98dd4253e2d8590f1c1b3d
+  react-native-webrtc: 559be81da074a059140db50a5f8268b6328d4fab
   React-perflogger: 6c01400e9d679980209c5debe4438eafd7e656b0
   React-RCTAnimation: 00220b81e0f8bc61cc1283544fc78d4f5cc8f857
   React-RCTBlob: a23e9da46cd0523a130b4658a22ffa758c459cc4
@@ -540,10 +545,11 @@ SPEC CHECKSUMS:
   ReactCommon: e3818869621c119aea08bd5ce8ed0b8c64abeafe
   RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
   RNScreens: 85d3880b52d34db7b8eeebe2f1a0e807c05e69fa
-  SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
+  SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
+  WebRTC: a762512176db11e1be6cb814c26f9cbfca6ade74
   Yoga: 486daad4f5db121eb2e831e2aae8ad994011573f
   YogaKit: 1e22bf2228b3a5ac8cc88965153061ae92c494b5
 
-PODFILE CHECKSUM: 0e2d1240a203f374e3e47be160fd15bc75d45068
+PODFILE CHECKSUM: 9869ca4977ac114cc9c047b15136f63cc9487604
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.3

--- a/ios/TestApp.xcodeproj/project.pbxproj
+++ b/ios/TestApp.xcodeproj/project.pbxproj
@@ -253,7 +253,6 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				B0563F1945F562EA860C8FFD /* [CP] Embed Pods Frameworks */,
 				2D6599C4C57E3845B3362D38 /* [CP] Copy Pods Resources */,
-				0A7620132AD6E95000B25F63 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -275,6 +274,7 @@
 				2D02E4791E0B4A5D006451C7 /* Resources */,
 				2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */,
 				A8E5427FAF6B986158E2633A /* [CP] Copy Pods Resources */,
+				D46E476AA326815930F22144 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -294,6 +294,7 @@
 				2D02E48D1E0B4A5D006451C7 /* Frameworks */,
 				2D02E48E1E0B4A5D006451C7 /* Resources */,
 				C9FF6748541601D7E0EE9EFE /* [CP] Copy Pods Resources */,
+				435E04E9659EFC79282C5E9B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -454,6 +455,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestApp/Pods-TestApp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		435E04E9659EFC79282C5E9B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS-TestApp-tvOSTests/Pods-TestApp-tvOS-TestApp-tvOSTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS-TestApp-tvOSTests/Pods-TestApp-tvOS-TestApp-tvOSTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS-TestApp-tvOSTests/Pods-TestApp-tvOS-TestApp-tvOSTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		5989D29631C9458163258B7D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -581,6 +599,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS-TestApp-tvOSTests/Pods-TestApp-tvOS-TestApp-tvOSTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D46E476AA326815930F22144 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS/Pods-TestApp-tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS/Pods-TestApp-tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestApp-tvOS/Pods-TestApp-tvOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FA9E4818ACF76DCCB207186D /* [CP] Check Pods Manifest.lock */ = {
@@ -839,7 +874,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Pods/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",

--- a/ios/WebRTC/WebRTC.podspec
+++ b/ios/WebRTC/WebRTC.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name             = "WebRTC"
+  s.version          = "0.0.112"
+  s.summary          = "WebRTC dependency"
+  s.homepage         = "https://github.com/CoSMoSoftware/libwebrtc"
+  s.license          = { :type => "MIT", :text => "MIT License" }
+  s.author           = { "Aravind Raveendran" => "aravind.raveendran@dolby.com" }
+  s.source           = { :http => 'file:' + __dir__ + '/../libWebRTC.zip' }
+  s.ios.deployment_target   = "12.4"
+  s.tvos.deployment_target  = "12.4"
+  s.vendored_frameworks     = [ 'libWebRTC/Frameworks/WebRTC.xcframework' ]
+  s.source_files            = "libWebRTC/Frameworks/*.{h,m,swift}"
+  s.preserve_paths          = "*"
+end

--- a/ios/libWebRTC.zip
+++ b/ios/libWebRTC.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7fba36d0d5982f83aec3a0ea7edfd7b44b9d1ec8d64f59c7b17d413f12f836b
-size 151449043
+oid sha256:4a2fedd96a8ab33c1ff9b5471910336a335cf12767f5eb34badf2b42496fee89
+size 58797842

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@dolbyio/uikit-react-native": "file:./src/uikit/",
     "@millicast/sdk": "^0.1.39",
+    "@react-native-async-storage/async-storage": "^1.17.0",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "@types/color": "3.0.3",
@@ -29,16 +30,15 @@
     "react-native-screens": "^3.20.0",
     "react-native-webrtc": "github:montanaeli/react-native-webrtc",
     "react-redux": "^8.1.3",
-    "redux": "^4.2.1",
-    "@react-native-async-storage/async-storage": "^1.17.0"
+    "redux": "^4.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
-    "babel-jest": "^26.6.3",
-    "babel-plugin-module-resolver": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
+    "babel-jest": "^26.6.3",
+    "babel-plugin-module-resolver": "^4.1.0",
     "eslint": "^8.23.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5661,7 +5661,7 @@ react-native-screens@^3.20.0:
 
 "react-native-webrtc@github:montanaeli/react-native-webrtc":
   version "111.0.1"
-  resolved "https://codeload.github.com/montanaeli/react-native-webrtc/tar.gz/63651a72f1f59d58d9cf5516bf2967c1a897537a"
+  resolved "https://codeload.github.com/montanaeli/react-native-webrtc/tar.gz/2c7b6e370e245dee84a72912f6e246ef885a0955"
   dependencies:
     adm-zip "0.5.9"
     base64-js "1.5.1"


### PR DESCRIPTION
Description:

1. Fixing the XCFramework package structure as it was corrupted and re-compressed it into a new libWebRTC.zip which was already managed in the repo through git-lfs
2. Added a local pod (WebRTC/WebRTC.podspec) for supplying WebRTC.xcframework dependency
