### PR TITLE
Add a separate header with a `clear all streams` button in TV platforms

### DIFF
--- a/src/screens/savedStreams/SavedStreams.style.ts
+++ b/src/screens/savedStreams/SavedStreams.style.ts
@@ -19,5 +19,12 @@ const styles = () =>
       flexDirection: 'row',
       flex: 1,
     },
+    noStreamsMessageWrapper: {
+      flexDirection: 'column',
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginTop: -100,
+    },
   });
 export default styles;

--- a/src/screens/savedStreams/SavedStreams.style.ts
+++ b/src/screens/savedStreams/SavedStreams.style.ts
@@ -5,6 +5,12 @@ const styles = () =>
     wrapper: {
       flex: 1,
     },
+    headerViewWrapperTV: {
+      flexDirection: 'row',
+      height: 75,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
     streamListSectionHeaderWrapper: {
       flexDirection: 'row',
       flex: 1,

--- a/src/screens/savedStreams/SavedStreams.tsx
+++ b/src/screens/savedStreams/SavedStreams.tsx
@@ -69,9 +69,10 @@ export const SavedStreams = ({ navigation }) => {
     navigation.setOptions({
       headerShown: !Platform.isTV,
       headerTitle: savedStreamsHeaderText,
-      headerRight: () => (
-        <IconButton backgroundColor="transparent" icon="trash" size="m" onPress={clearSavedStreamsAlert} />
-      ),
+      headerRight: () =>
+        streamsList.length > 0 && (
+          <IconButton backgroundColor="transparent" icon="trash" size="m" onPress={clearSavedStreamsAlert} />
+        ),
     });
   }, []);
 
@@ -82,19 +83,28 @@ export const SavedStreams = ({ navigation }) => {
           <View style={styles.headerViewWrapperTV}>
             <View />
             <Text id="savedStreamsHeaderText" type="H2" />
-            <IconButton backgroundColor="transparent" icon="trash" size="m" onPress={clearSavedStreamsAlert} />
+            {streamsList.length > 0 && (
+              <IconButton backgroundColor="transparent" icon="trash" size="m" onPress={clearSavedStreamsAlert} />
+            )}
           </View>
         )}
-        <ScrollView>
-          <View style={styles.streamListSectionHeaderWrapper}>
-            <Text id="lastPlayedStreamText" type="bodyDefault" style={styles.streamListSectionHeaderText} />
+        {streamsList.length > 0 ? (
+          <ScrollView>
+            <View style={styles.streamListSectionHeaderWrapper}>
+              <Text id="lastPlayedStreamText" type="bodyDefault" style={styles.streamListSectionHeaderText} />
+            </View>
+            <StreamList streams={streamsList.slice(0, 1)} onPlayStream={handlePlayStream} />
+            <View style={styles.streamListSectionHeaderWrapper}>
+              <Text id="allStreamsText" type="bodyDefault" style={styles.streamListSectionHeaderText} />
+            </View>
+            <StreamList streams={streamsList} onPlayStream={handlePlayStream} />
+          </ScrollView>
+        ) : (
+          <View style={styles.noStreamsMessageWrapper}>
+            <Text id="noSavedStreamsTitleText" type="h1" align="center" numberOfLines={2} />
+            <Text id="noSavedStreamssubtitleText" type="bodyDefault" color="secondary.200" />
           </View>
-          <StreamList streams={streamsList.slice(0, 1)} onPlayStream={handlePlayStream} />
-          <View style={styles.streamListSectionHeaderWrapper}>
-            <Text id="allStreamsText" type="bodyDefault" style={styles.streamListSectionHeaderText} />
-          </View>
-          <StreamList streams={streamsList} onPlayStream={handlePlayStream} />
-        </ScrollView>
+        )}
       </SafeAreaView>
       <WelcomeFooter />
     </Layout>

--- a/src/screens/savedStreams/SavedStreams.tsx
+++ b/src/screens/savedStreams/SavedStreams.tsx
@@ -67,7 +67,7 @@ export const SavedStreams = ({ navigation }) => {
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerShown: !(Platform.OS === 'ios' && Platform.isTV),
+      headerShown: !Platform.isTV,
       headerTitle: savedStreamsHeaderText,
       headerRight: () => (
         <IconButton backgroundColor="transparent" icon="trash" size="m" onPress={clearSavedStreamsAlert} />
@@ -78,12 +78,18 @@ export const SavedStreams = ({ navigation }) => {
   return (
     <Layout testID="SavedStreamsScreen">
       <SafeAreaView style={styles.wrapper}>
+        {Platform.isTV && (
+          <View style={styles.headerViewWrapperTV}>
+            <View />
+            <Text id="savedStreamsHeaderText" type="H2" />
+            <IconButton backgroundColor="transparent" icon="trash" size="m" onPress={clearSavedStreamsAlert} />
+          </View>
+        )}
         <ScrollView>
           <View style={styles.streamListSectionHeaderWrapper}>
             <Text id="lastPlayedStreamText" type="bodyDefault" style={styles.streamListSectionHeaderText} />
           </View>
           <StreamList streams={streamsList.slice(0, 1)} onPlayStream={handlePlayStream} />
-
           <View style={styles.streamListSectionHeaderWrapper}>
             <Text id="allStreamsText" type="bodyDefault" style={styles.streamListSectionHeaderText} />
           </View>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -24,5 +24,7 @@
   "allStreamsText": "All",
   "clearSavedStreamsAlertText": "Are you sure you want to clear the saved streams?",
   "clearSavedStreamsAlertCancelButton": "Cancel",
-  "clearSavedStreamsAlertClearButton": "Clear"
+  "clearSavedStreamsAlertClearButton": "Clear",
+  "noSavedStreamsTitleText": "You don’t have any streams viewed",
+  "noSavedStreamssubtitleText": "View a stream to add it to your history."
 }


### PR DESCRIPTION
### Description:

Bugfix: 
1. Add a separate header with a `clear all streams` button in TV platforms
2. Add `no saved streams` screen content