### PR TITLE
Fix: Use MillicastViewRef.current for project call

### DIFF
--- a/src/screens/multiview/MultiView.tsx
+++ b/src/screens/multiview/MultiView.tsx
@@ -262,7 +262,7 @@ export const MultiView = ({ navigation }) => {
       const mediaStream = new MediaStream();
       const transceiver = await millicastViewRef.current.addRemoteTrack('video', [mediaStream]);
       const mediaId = transceiver.mid;
-      await millicastView.project(sourceId, [
+      await millicastViewRef.current.project(sourceId, [
         {
           media: 'video',
           mediaId,

--- a/src/screens/multiview/MultiView.tsx
+++ b/src/screens/multiview/MultiView.tsx
@@ -307,7 +307,13 @@ export const MultiView = ({ navigation }) => {
 
   useEffect(() => {
     if (netInfo.isConnected === false) {
-      resetState();
+      dispatch({ type: 'viewer/setStreams', payload: [] });
+      dispatch({
+        type: 'viewer/setSelectedSource',
+        payload: { url: null, mid: null },
+      });
+      dispatch({ type: 'viewer/setSourceIds', payload: [] });
+
       // Set error when there is no network connection
       dispatch({ type: 'viewer/setError', payload: 'No internet connection' });
     }


### PR DESCRIPTION
Description

Fixes a typo using wrong object for `project` call